### PR TITLE
수정 - table이름 수정, comments table 수정, post_tags 다대다 관계 수정

### DIFF
--- a/src/models/comments.model.ts
+++ b/src/models/comments.model.ts
@@ -19,7 +19,7 @@ export interface IcommentsAttributes {
   content: string,
   userId: number,
   postId: number,
-  commentId?: number,
+  commentId?: number | null,
   //createdAt: Date,
   //updatedAt: Date
 }
@@ -49,7 +49,7 @@ export class Comments extends Model<IcommentsAttributes>{
   public static content?: string;
   public static userId?: number;
   public static postId?: number;
-  public static commentId?: number;
+  public static commentId?: number | null;
 
   //public readonly createdAt?: Date;
   //public readonly updatedAt?: Date;
@@ -88,7 +88,8 @@ Comments.init({
   //commentId는 왜 필요?? 그냥 id랑 무슨 차이가??
   commentId: {
     type: DataTypes.INTEGER,
-    allowNull: false
+    allowNull: true,
+    defaultValue:null
   },
   // createdAt:{
   //   type: DataTypes.DATE,
@@ -100,7 +101,8 @@ Comments.init({
   // }
 }, {
   sequelize,
-  modelName: 'comment',
+  modelName: 'comments',
+  tableName: 'comments',
   freezeTableName: true,
   timestamps: true,
     //createdAt: true,

--- a/src/models/posts.model.ts
+++ b/src/models/posts.model.ts
@@ -42,7 +42,7 @@ import { Users } from './users.model';
      * This method is not a part of Sequelize lifecycle.
      * The `models/index` file will call this method automatically.
      */
-     public readonly id?: number;
+     public static readonly id?: number;
      public static content?: string;
      public static userId?: number;
      public static public?: boolean;

--- a/src/models/posts_tags.model.ts
+++ b/src/models/posts_tags.model.ts
@@ -48,8 +48,10 @@ export class Posts_Tags extends Model<Iposts_tagsAttributes> {
      //public readonly updatedAt?: Date;
 
      public static associations: {
-      postsbelongsToManyTags:Association<Posts, Tags>
-      tagsbelongsToManyPosts: Association<Tags, Posts>,
+       postsHasManyPosts_Tags:Association<Posts, Posts_Tags>;
+       post_TagsBelongToPosts:Association<Posts_Tags, Posts>;
+       tagsHasManyPosts_Tags:Association<Tags, Posts_Tags>;
+       post_TagsBelongToTags:Association<Posts_Tags, Tags>;
      };
     
      
@@ -80,8 +82,8 @@ export class Posts_Tags extends Model<Iposts_tagsAttributes> {
       // }
     }, {
       sequelize,
-      modelName: 'post_tag',
-      tableName: 'post_tag',
+      modelName: 'posts_tags',
+      tableName: 'posts_tags',
       freezeTableName: true,
       timestamps: true,
     //createdAt: true,
@@ -89,19 +91,30 @@ export class Posts_Tags extends Model<Iposts_tagsAttributes> {
     });
   //   return Posts_Tags;
   //  };
+  Posts.hasMany(Posts_Tags, {
+    sourceKey: 'id',
+    foreignKey: 'postId',
+    onDelete: 'CASCADE',
+    as: 'postsHasManyPosts_Tags'
+  });
+  Posts_Tags.belongsTo(Posts,{
+    targetKey:'id',
+    foreignKey: 'postId',
+    onDelete: 'CASCADE',
+    as: 'post_TagsBelongToPosts'
+  });
 
-  Tags.belongsToMany(Posts, {
-    through: 'post_tag',
+  Tags.hasMany(Posts_Tags, {
     sourceKey: 'id',
     foreignKey: 'tagId',
     onDelete: 'CASCADE',
-    as: 'tagsbelongsToManyPosts'
+    as: 'tagsHasManyPosts_Tags'
   });
-   Posts.belongsToMany(Tags, {
-      foreignKey: 'postId',
-      sourceKey: 'id',
-      onDelete: 'CASCADE',
-      through: 'post_tag',
-      as: 'postsbelongsToManyTags'
-    });
+  Posts_Tags.belongsTo(Tags,{
+    targetKey:'id',
+    foreignKey: 'tagId',
+    onDelete: 'CASCADE',
+    as: 'post_TagsBelongToTags'
+  });
+
 

--- a/src/models/recentsearchs.model.ts
+++ b/src/models/recentsearchs.model.ts
@@ -87,7 +87,8 @@ export class RecentSearchs extends Model<IrecentSearchsAttributes>{
     // }
   }, {
     sequelize,
-    modelName: 'recentsearch',
+    modelName: 'recentsearchs',
+    tableName:'recentsearchs',
     freezeTableName: true,
     timestamps: true,
     //createdAt: true,

--- a/src/models/tags.model.ts
+++ b/src/models/tags.model.ts
@@ -70,7 +70,8 @@ import { Posts } from './posts.model';
       // }
     }, {
       sequelize,
-      modelName: 'tag',
+      modelName: 'tags',
+      tableName: 'tags',
       freezeTableName: true,
       timestamps: true,
     //createdAt: true,


### PR DESCRIPTION
table이름 수정 - table 이름 단순 수정
comments table 수정 - commentId에 null이 들어가는 상황이 있으므로 not null설정 제거
post_tags 다대다 관계 수정 - 다대다 관계를 설정했었으나 데이터베이스에서 확인 시 적용이 되지 않아 관계성 설정 방법 변경